### PR TITLE
added option to read metget configuration

### DIFF
--- a/src/cosmos/cosmos_configuration.py
+++ b/src/cosmos/cosmos_configuration.py
@@ -177,10 +177,13 @@ class Configuration:
         self.stations = Stations()
         self.stations.read()
 
+        # Add metget_api configuration path for coamps-tc data (save only path to be able to change priority storm while cosmos is running)
+        self.metget_config_path = os.path.join(self.path.main, "configuration", "metget_config.toml")
+
         # Available meteo sources
         cosmos.log("Reading meteo sources ...")    
         read_meteo_sources()
-
+   
         # Find all available super regions
         cosmos.log("Reading super regions ...")    
         self.super_region = {}

--- a/src/cosmos/cosmos_meteo.py
+++ b/src/cosmos/cosmos_meteo.py
@@ -63,7 +63,8 @@ def read_meteo_sources():
                       "forecast",
                       crs=CRS.from_epsg(4326),
                       delay=6,
-                      time_interval=1)
+                      time_interval=1,
+                      config_path=cosmos.config.metget_config_path)
     cosmos.meteo_source.append(src)
 
     src = MeteoSource("coamps_tc_retro_forecast",


### PR DESCRIPTION
Added part that allows for reading a metget coamps config file for coamps forecasting data.

The config file should be a toml with the following format:

**apikey** = ".." # apikey provided
**endpoint** = "https://api.metget.org" #url of the endpoint
**api_version** = 2 # this is the version of metget that is used
**tau** = 4 # the first tau hours that will be used from the previous forecast
**priority_storm** = "10L" # "tcvitals" or "#L"

the config file should be located in **cosmos/configuration/metget_config.toml**